### PR TITLE
Track last-opened paths based on file roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ all: setup version format mypy pylint
 setup:
 	poetry install -E gui
 	# Mac build hack: force any locally-built Pillow universal package into the environment
-	[ -n "$(shell find build -maxdepth 1 -name '*_universal2.whl' -print -quit)" ] && \
-		poetry run pip install build/*_universal2.whl --force-reinstall || true
+	[ -n "$(shell find build/local-wheels -maxdepth 1 -name '*_universal2.whl' -print -quit)" ] && \
+		poetry run pip install build/local-wheels/*_universal2.whl --force-reinstall || true
 
 .PHONY: format
 format:

--- a/bandcrash/gui/__init__.py
+++ b/bandcrash/gui/__init__.py
@@ -226,7 +226,7 @@ class AlbumEditor(QtWidgets.QMainWindow):
                       QtGui.QAction.PreferencesRole)
 
         self.filename = path
-        self.data: typing.Dict[str, typing.Any] = {'tracks': []}
+        self.data: dict[str, typing.Any] = {'tracks': []}
         if path:
             self.reload(path)
             if '_gui' in self.data:
@@ -312,10 +312,10 @@ class AlbumEditor(QtWidgets.QMainWindow):
     def file_open():
         """ Dialog box to open an existing file """
         role = FileRole.ALBUM
-        path, _ = QtWidgets.QFileDialog.getOpenFileName(
-            caption="Open album",
-            filter=role.file_filter,
-            dir=role.default_directory)
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(None,
+                                                        "Open album",
+                                                        role.default_directory,
+                                                        role.file_filter)
         if path:
             role.default_directory = os.path.dirname(path)
             editor = AlbumEditor(path)
@@ -325,7 +325,7 @@ class AlbumEditor(QtWidgets.QMainWindow):
         """ Load from the backing storage """
         with open(path, 'r', encoding='utf8') as file:
             try:
-                self.data = json.load(file)
+                self.data = typing.cast(dict[str, typing.Any], json.load(file))
                 if 'tracks' not in self.data:
                     raise KeyError('tracks')
             except (json.decoder.JSONDecodeError, KeyError, TypeError):
@@ -429,9 +429,11 @@ class AlbumEditor(QtWidgets.QMainWindow):
 
         role = FileRole.ALBUM
         path, _ = QtWidgets.QFileDialog.getSaveFileName(
-            caption="Select your album file",
-            filter=role.file_filter,
-            dir=os.path.dirname(self.filename) or role.default_directory)
+            self,
+            "Select your album file",
+            os.path.dirname(self.filename) or role.default_directory,
+            role.file_filter,
+        )
         if path:
             self.renormalize_paths(self.filename, path)
             self.filename = path

--- a/bandcrash/gui/datatypes.py
+++ b/bandcrash/gui/datatypes.py
@@ -1,6 +1,11 @@
 """ Data type conversion functions """
 
+import typing
+
 from PySide6.QtCore import Qt
+
+TrackData = dict[str, typing.Any]
+TrackList = list[TrackData]
 
 
 def to_checkstate(val):

--- a/bandcrash/gui/datatypes.py
+++ b/bandcrash/gui/datatypes.py
@@ -1,11 +1,11 @@
 """ Data type conversion functions """
 
-from PySide6 import QtCore
+from PySide6.QtCore import Qt
 
 
 def to_checkstate(val):
     """ Convert a bool to a qt CheckState """
-    return QtCore.Qt.Checked if val else QtCore.Qt.Unchecked
+    return Qt.CheckState.Checked if val else Qt.CheckState.Unchecked
 
 
 def apply_text_fields(data, fields, xform=lambda x: x):
@@ -28,7 +28,7 @@ def apply_checkbox_fields(data, fields):
     :param list fields: List of (dict_key, widget, default)
     """
     for key, widget, dfl in fields:
-        value = widget.checkState() == QtCore.Qt.Checked
+        value = widget.checkState() == Qt.CheckState.Checked
         if value != dfl:
             data[key] = value
         elif key in data:

--- a/bandcrash/gui/file_utils.py
+++ b/bandcrash/gui/file_utils.py
@@ -1,0 +1,53 @@
+""" File handling utilities """
+
+import enum
+import itertools
+import logging
+
+from PySide6.QtCore import QSettings, QStandardPaths
+
+from .. import images
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FileRole(enum.Enum):
+    """ File roles, for file selector widgets """
+
+    def __init__(self, label, file_filter):
+        self.label = label
+        self.file_filter = file_filter
+
+    ALBUM = ("album", "Bandcrash album (*.bcalbum *.json)")
+    AUDIO = ("track", "Audio files (*.wav *.ogg *.flac *.mp3 *.aif *.aiff)")
+    IMAGE = (
+        "image", f"Image files ({' '.join(f'*{ext}' for ext in images.known_extensions())})")
+    OUTPUT = ("output", '')
+
+    @property
+    def default_directory(self):
+        """ Get the default system-level directory for this file role """
+        settings = QSettings()
+        settings.beginGroup("defaultDirs")
+
+        if settings.contains(self.name):
+            return settings.value(self.name)
+
+        sloc = QStandardPaths.StandardLocation
+
+        for candidate in itertools.chain(
+                QStandardPaths.standardLocations(loc)
+                for loc in (sloc.MusicLocation, sloc.DocumentsLocation, sloc.HomeLocation)):
+            return candidate
+
+        LOGGER.warning(
+            "Couldn't find default directory for role %s", self.name)
+        return ''
+
+    @default_directory.setter
+    def default_directory(self, file_dir):
+        """ Set the default system-level directory for this file role """
+        settings = QSettings()
+        settings.beginGroup("defaultDirs")
+        settings.setValue(self.name, file_dir)
+        settings.sync()

--- a/bandcrash/gui/file_utils.py
+++ b/bandcrash/gui/file_utils.py
@@ -23,6 +23,7 @@ class FileRole(enum.Enum):
     IMAGE = (
         "image", f"Image files ({' '.join(f'*{ext}' for ext in images.known_extensions())})")
     OUTPUT = ("output", '')
+    BINARY = ("binary", '')
 
     @property
     def default_directory(self):

--- a/bandcrash/gui/widgets.py
+++ b/bandcrash/gui/widgets.py
@@ -15,6 +15,12 @@ from .file_utils import FileRole
 LOGGER = logging.getLogger(__name__)
 
 
+def wrap_layout(parent: QWidget, layout: QLayout):
+    widget = QWidget(parent)
+    widget.setLayout(layout)
+    return widget
+
+
 class FileSelector(QWidget):
     """ A file selector textbox with ... button """
 
@@ -29,7 +35,7 @@ class FileSelector(QWidget):
 
         self.role = role
         self.album_editor = album_editor
-        self.file_path = QLineEdit(text=text)
+        self.file_path = QLineEdit(text)
         self.button = QPushButton("...")
 
         layout.addWidget(self.file_path)
@@ -87,14 +93,15 @@ class FuturesProgress(QWidget):
         self.futures = futures
         self.mapping = {}
 
-        self.layout = QFormLayout()
+        self.form = QFormLayout(self)
         for key, tasks in futures.items():
-            progress_bar = QProgressBar(
-                minimum=0, maximum=len(tasks))
+            progress_bar = QProgressBar(self)
+            progress_bar.setMinimum(0)
+            progress_bar.setMaximum(len(tasks))
             self.mapping[key] = progress_bar
-            self.layout.addRow(key, progress_bar)
+            self.form.addRow(key, progress_bar)
 
-        self.setLayout(self.layout)
+        self.setLayout(self.form)
 
     def update(self):
         """ Update the progress indicators; returns True if everything's done """
@@ -102,7 +109,7 @@ class FuturesProgress(QWidget):
             if key in self.mapping:
                 if len([task for task in tasks if task.done()]) == len(tasks):
                     # This task set is finished, so we can remove the progress bar
-                    self.layout.removeRow(self.mapping[key])
+                    self.form.removeRow(self.mapping[key])
                     del self.mapping[key]
 
         return bool(self.mapping)
@@ -181,10 +188,14 @@ class FlowLayout(QLayout):
         for item in self._item_list:
             style = item.widget().style()
             layout_spacing_x = style.layoutSpacing(
-                QSizePolicy.PushButton, QSizePolicy.PushButton, Qt.Horizontal
+                QSizePolicy.ControlType.PushButton,
+                QSizePolicy.ControlType.PushButton,
+                Qt.Orientation.Horizontal
             )
             layout_spacing_y = style.layoutSpacing(
-                QSizePolicy.PushButton, QSizePolicy.PushButton, Qt.Vertical
+                QSizePolicy.ControlType.PushButton,
+                QSizePolicy.ControlType.PushButton,
+                Qt.Orientation.Vertical
             )
             space_x = spacing + layout_spacing_x
             space_y = spacing + layout_spacing_y

--- a/bandcrash/gui/widgets.py
+++ b/bandcrash/gui/widgets.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def wrap_layout(parent: QWidget, layout: QLayout):
+    """ Wrap a layout in a QWidget, which is for some reason not a standard Qt function """
     widget = QWidget(parent)
     widget.setLayout(layout)
     return widget

--- a/bandcrash/images.py
+++ b/bandcrash/images.py
@@ -103,3 +103,11 @@ def fix_orientation(image: PIL.Image) -> PIL.Image:
         # either no EXIF tags or no orientation tag
         pass
     return image
+
+
+@functools.lru_cache()
+def known_extensions():
+    """ Get a list of known image file extensions """
+    # adapted from https://stackoverflow.com/a/71114152/318857
+    exts = PIL.Image.registered_extensions()
+    return {ex for ex, f in exts.items() if f in PIL.Image.OPEN}

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,0 @@
-[mypy]
-exclude = bandcrash/gui

--- a/poetry.lock
+++ b/poetry.lock
@@ -577,7 +577,7 @@ testutils = ["gitpython (>3)"]
 name = "pyside6"
 version = "6.6.0"
 description = "Python bindings for the Qt cross-platform application and UI framework"
-optional = true
+optional = false
 python-versions = "<3.13,>=3.8"
 files = [
     {file = "PySide6-6.6.0-cp38-abi3-macosx_11_0_universal2.whl", hash = "sha256:8103f14ed46a05e81acccbfc8388e3321e392fe54f3aa4a13336bd2ed8af5cd4"},
@@ -595,7 +595,7 @@ shiboken6 = "6.6.0"
 name = "pyside6-addons"
 version = "6.6.0"
 description = "Python bindings for the Qt cross-platform application and UI framework (Addons)"
-optional = true
+optional = false
 python-versions = "<3.13,>=3.8"
 files = [
     {file = "PySide6_Addons-6.6.0-cp38-abi3-macosx_11_0_universal2.whl", hash = "sha256:82fe1bb6a1aabf5ab3d8632072dc908aa37fc75b4b46e520258c441bd6b103fb"},
@@ -612,7 +612,7 @@ shiboken6 = "6.6.0"
 name = "pyside6-essentials"
 version = "6.6.0"
 description = "Python bindings for the Qt cross-platform application and UI framework (Essentials)"
-optional = true
+optional = false
 python-versions = "<3.13,>=3.8"
 files = [
     {file = "PySide6_Essentials-6.6.0-cp38-abi3-macosx_11_0_universal2.whl", hash = "sha256:26d27e3e3a18acbc770a69a30774fd345414fe4932fcb89d2cfc4fc130c3eb33"},
@@ -623,6 +623,24 @@ files = [
 
 [package.dependencies]
 shiboken6 = "6.6.0"
+
+[[package]]
+name = "pyside6-stubs"
+version = "6.4.2.0"
+description = "PEP561 stub files for the *Qt for Python/PySide6* framework"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "PySide6-stubs-6.4.2.0.tar.gz", hash = "sha256:d5578eb1597d1c07831c899b35636410b08915a4695ce6e41cceb6707c400fcf"},
+    {file = "PySide6_stubs-6.4.2.0-py3-none-any.whl", hash = "sha256:e825ded4b3555d540f297f405e3a9dc0943c032a96c53184cf644a8e4c4a6b0b"},
+]
+
+[package.dependencies]
+mypy = ">=1.0"
+PySide6 = ">=6.0"
+
+[package.extras]
+dev = ["pytest"]
 
 [[package]]
 name = "pywin32-ctypes"
@@ -752,7 +770,7 @@ testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jar
 name = "shiboken6"
 version = "6.6.0"
 description = "Python/C++ bindings helper module"
-optional = true
+optional = false
 python-versions = "<3.13,>=3.8"
 files = [
     {file = "shiboken6-6.6.0-cp38-abi3-macosx_11_0_universal2.whl", hash = "sha256:bf23c43e53ffe6097853666ced05358c6640c378e992902a36c4cf77efb0223b"},
@@ -848,4 +866,4 @@ gui = ["pyside6"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "20913edc0528720b3464032ca41666f1c44b9aec830d7f5bdde37e9969cdb70d"
+content-hash = "9f4c349285290735d44e3a1f1c069b6380357f0c714a313f2d63f1531a1dbeda"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ types-python-slugify = "^8.0.0.3"
 types-chardet = "^5.0.4.6"
 pyinstaller = "^6.0.0"
 delocate = "^0.10.4"
+pyside6-stubs = "^6.4.2.0"
 
 [tool.poetry.extras]
 gui = [ "pyside6" ]

--- a/tests/album/save_last_paths.bcalbum
+++ b/tests/album/save_last_paths.bcalbum
@@ -1,0 +1,70 @@
+{
+   "artist": "Test artist",
+   "year": 2022,
+   "title": "Test album",
+   "highlight_color": "#770077",
+   "artwork": "album_cover.png",
+   "genre": "blipcore",
+   "tracks": [
+      {
+         "filename": "test track.wav",
+         "lyrics": [
+            "I'm not sure just how I feel",
+            "When everything's just fine",
+            "Blah blah blah blah so surreal",
+            "Something borrowed time",
+            "",
+            "How you doing, now?!"
+         ]
+      },
+      {
+         "filename": "test track.wav",
+         "title": "This has a title"
+      },
+      {
+         "filename": "test track.wav",
+         "title": "This has no preview",
+         "preview": false
+      },
+      {
+         "filename": "test track.wav",
+         "title": "This track is hidden",
+         "artwork": "hidden_track.png",
+         "hidden": true
+      },
+      {
+         "filename": "test track.wav",
+         "artwork": "../../art/bclogo.png",
+         "lyrics": "lyric-file.txt",
+         "genre": "lo-fi jazzcore",
+         "group": "Meows I Have Known"
+      },
+      {
+         "filename": "test track.wav",
+         "title": "A different artist",
+         "artist": "Sluggy Puppernutters",
+         "lyrics": "lyrics-iso8859.txt",
+         "group": "Meows I Have Known"
+      },
+      {
+         "filename": "test track.wav",
+         "title": "Test Track"
+      },
+      {
+         "filename": "../derived/unnumbered track.wav",
+         "title": "Unnumbered Track"
+      }
+   ],
+   "_gui": {
+      "geom": [
+         -1724,
+         295,
+         1244,
+         929
+      ],
+      "lastdir": {
+         "AUDIO": "../derived",
+         "IMAGE": "../../art"
+      }
+   }
+}

--- a/tests/moved-dir.bcalbum
+++ b/tests/moved-dir.bcalbum
@@ -1,0 +1,70 @@
+{
+   "artist": "Test artist",
+   "year": 2022,
+   "title": "Test album",
+   "highlight_color": "#770077",
+   "artwork": "album/album_cover.png",
+   "genre": "blipcore",
+   "tracks": [
+      {
+         "filename": "album/test track.wav",
+         "lyrics": [
+            "I'm not sure just how I feel",
+            "When everything's just fine",
+            "Blah blah blah blah so surreal",
+            "Something borrowed time",
+            "",
+            "How you doing, now?!"
+         ]
+      },
+      {
+         "filename": "album/test track.wav",
+         "title": "This has a title"
+      },
+      {
+         "filename": "album/test track.wav",
+         "title": "This has no preview",
+         "preview": false
+      },
+      {
+         "filename": "album/test track.wav",
+         "title": "This track is hidden",
+         "artwork": "hidden_track.png",
+         "hidden": true
+      },
+      {
+         "filename": "album/test track.wav",
+         "artwork": "../../art/bclogo.png",
+         "lyrics": "lyric-file.txt",
+         "genre": "lo-fi jazzcore",
+         "group": "Meows I Have Known"
+      },
+      {
+         "filename": "album/test track.wav",
+         "title": "A different artist",
+         "artist": "Sluggy Puppernutters",
+         "lyrics": "lyrics-iso8859.txt",
+         "group": "Meows I Have Known"
+      },
+      {
+         "filename": "album/test track.wav",
+         "title": "Test Track"
+      },
+      {
+         "filename": "derived/unnumbered track.wav",
+         "title": "Unnumbered Track"
+      }
+   ],
+   "_gui": {
+      "geom": [
+         -1724,
+         295,
+         1244,
+         929
+      ],
+      "lastdir": {
+         "AUDIO": "derived",
+         "IMAGE": "../art"
+      }
+   }
+}


### PR DESCRIPTION
Now file open dialogs will try to go to a reasonable default, which is tracked both per-album and globally to the application, fixing one of my biggest pet peeves with how file open dialogs work in most cross-platform applications. You'd think Qt would have standard functionality for this, but noooooo

Also got tired of not being able to run the GUI through mypy and did all the stuff necessary to make mypy validate (which unfortunately means making a lot of code more verbose because of some of the weird stuff PySide6 does to make the Python API act more like C++, sigh).

Anyway this fixes #51 