### PR TITLE
Use devpi instance for universal2 wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@ all: setup format mypy pylint
 setup:
 	./bump-version.sh
 	poetry install -E gui
-	# Mac build hack: force any locally-built Pillow universal package into the environment
-	[ -n "$(shell find build/local-wheels -maxdepth 1 -name '*_universal2.whl' -print -quit)" ] && \
-		poetry run pip install build/local-wheels/*_universal2.whl --force-reinstall || true
 
 .PHONY: format
 format:
@@ -59,10 +56,10 @@ clean:
 
 .PHONY: upload
 upload: clean test build
-	poetry publish
+	poetry publish -r pypi
 
 .PHONY: app
-app: format pylint mypy
+app: setup format pylint mypy
 	poetry run pyInstaller Bandcrash.spec -y
 
 .PHONY: upload-mac

--- a/make-universal2.sh
+++ b/make-universal2.sh
@@ -1,18 +1,23 @@
 #!/bin/sh
 # Generate the latest local universal2 wheels
 
-mkdir -p build
-cd build
+mkdir -p build/fuse-universal2
+cd build/fuse-universal2
+
+poetry run devpi use https://m.devpi.net/fluffy/prod
+poetry run devpi login fluffy
 
 for pkg in Pillow ; do
-    rm $pkg-*.whl
+    poetry run devpi use pypi
+    rm -f $pkg-*.whl
     for platform in macosx_10_10_x86_64 macosx_11_0_arm64 ; do
         poetry run pip download --only-binary=:all: --platform $platform $pkg
     done
     mkdir -p tmp
     poetry run delocate-fuse -w tmp  $pkg-*.whl
-    outfile=$(basename $pkg-*_arm64.whl arm64.whl)universal2.whl
+    outfile=../dist/$(basename $pkg-*_arm64.whl arm64.whl)universal2.whl
     mv tmp/$pkg-*.whl $outfile
+
+    poetry run devpi use fluffy/prod
+    poetry run devpi upload --formats=bdist_wheel $outfile
 done
-
-

--- a/poetry.lock
+++ b/poetry.lock
@@ -458,6 +458,25 @@ docs = ["furo", "olefile", "sphinx (>=2.4)", "sphinx-copybutton", "sphinx-inline
 tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
 
 [[package]]
+name = "pillow"
+version = "10.1.0"
+description = "Python Imaging Library (Fork)"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Pillow-10.1.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:f05c4c7516b17ddbb5521f8084ba62e4962031ede3e359c677e44045c62650fd"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=2.4)", "sphinx-copybutton", "sphinx-inline-tabs", "sphinx-removed-in", "sphinxext-opengraph"]
+tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
+
+[package.source]
+type = "legacy"
+url = "https://m.devpi.net/fluffy/prod/+simple"
+reference = "devpi-fluffy"
+
+[[package]]
 name = "platformdirs"
 version = "3.11.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -546,17 +565,17 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "3.0.1"
+version = "3.0.2"
 description = "python code static checker"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "pylint-3.0.1-py3-none-any.whl", hash = "sha256:9c90b89e2af7809a1697f6f5f93f1d0e518ac566e2ac4d2af881a69c13ad01ea"},
-    {file = "pylint-3.0.1.tar.gz", hash = "sha256:81c6125637be216b4652ae50cc42b9f8208dfb725cdc7e04c48f6902f4dbdf40"},
+    {file = "pylint-3.0.2-py3-none-any.whl", hash = "sha256:60ed5f3a9ff8b61839ff0348b3624ceeb9e6c2a92c514d81c9cc273da3b6bcda"},
+    {file = "pylint-3.0.2.tar.gz", hash = "sha256:0d4c286ef6d2f66c8bfb527a7f8a629009e42c99707dec821a03e1b51a4c1496"},
 ]
 
 [package.dependencies]
-astroid = ">=3.0.0,<=3.1.0-dev0"
+astroid = ">=3.0.1,<=3.1.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -866,4 +885,4 @@ gui = ["pyside6"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "9f4c349285290735d44e3a1f1c069b6380357f0c714a313f2d63f1531a1dbeda"
+content-hash = "ce7e77c80ff0a6c010490b33ea0864ebea420c4879ebf8304b1661c9f45009f6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,13 @@ Jinja2 = "^3.0.3"
 chardet = "^4.0.0"
 pyside6 = {version = "^6.5.3", optional = true}
 pyffmpeg = "^2.4.2.18.1"
-pillow = "^10.1.0"
+pillow = [
+    { platform = "universal2", version = "^10.1.0", source = "devpi-fluffy" },
+    { platform = "win32", version = "^10.1.0", source = "pypi" },
+    { platform = "win64", version = "^10.1.0", source = "pypi" },
+    { platform = "linux", version = "^10.1.0", source = "pypi" },
+]
+
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "^2.0.4"
@@ -30,6 +36,16 @@ pyside6-stubs = "^6.4.2.0"
 
 [tool.poetry.extras]
 gui = [ "pyside6" ]
+
+[[tool.poetry.source]]
+name = "PyPI"
+priority = "primary"
+
+
+[[tool.poetry.source]]
+name = "devpi-fluffy"
+url = "https://m.devpi.net/fluffy/prod/+simple"
+priority = "explicit"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
This gets rid of the awful poetry.lock override and local build-deps thing. Still needs an automated means of building/updating the bdist_wheel, though.