### PR TITLE
Refactor data ownership for stability and correctness

### DIFF
--- a/tests/album/album.json
+++ b/tests/album/album.json
@@ -9,9 +9,11 @@
       {
          "filename": "test track.wav",
          "title": "This has a title",
-         "about": ["This album was made with Bandcrash.",
+         "about": [
+            "This album was made with Bandcrash.",
             "",
-            "![](../../art/bclogo.png)"]
+            "![](../../art/bclogo.png)"
+         ]
       },
       {
          "filename": "test track.wav",
@@ -89,6 +91,10 @@
          "filename": "test track.wav",
          "title": "3. Solave",
          "group": "A multi-movement work"
+      },
+      {
+         "filename": "test track.wav",
+         "title": "Test Track"
       }
    ],
    "_gui": {


### PR DESCRIPTION
Qt seems to do its own attempt at tracking reference cycles, which got confused by having the grandchild of the widget maintaining a reference to it, and was causing segfaults at garbage collection time.

Additionally, windows need a reference maintained to them or else garbage collection will delete them, apparently. You'd think Qt itself would maintain that reference. But Qt is weird.

Fixes #99 