### PR TITLE
Complete refactor of encode pipeline

### DIFF
--- a/bandcrash/cdda.py
+++ b/bandcrash/cdda.py
@@ -1,5 +1,6 @@
 """ bin/cue generator """
 
+import concurrent.futures
 import logging
 import os
 import os.path
@@ -230,7 +231,7 @@ class CDWriter:
                 print('\t'.join([
                     str(idx),
                     get_prop(track, 'title'),
-                    f'{int(minutes)}:{int(seconds+0.5):02.2}',
+                    f'{int(minutes)}:{seconds+0.5:02.2}',
                     get_prop(track, 'artist'),
                     get_prop(track, 'composer')
                 ]), file=tsv)
@@ -238,13 +239,32 @@ class CDWriter:
         self.protections.add(fname)
 
 
-def encode(album, input_dir, output_dir, protections):
+def encode(album, input_dir, output_dir, protections, pool):
     """ Run the bincue output process """
     processor = CDWriter(input_dir, output_dir, album, protections)
-    for track in album['tracks']:
-        processor.add_track(track)
+    futures: list[concurrent.futures.Future] = []
 
-    processor.commit()
-    processor.write_cue()
-    processor.write_kunaki_cue()
-    processor.write_tsv()
+    def task(wait_for, func, *args):
+        if wait_for:
+            wait_for.result()
+        func(*args)
+
+    def submit(wait_for, func, *args):
+        future = pool.submit(task, wait_for, func, *args)
+        futures.append(future)
+        return future
+
+    last_step = None
+
+    for track in album['tracks']:
+        last_step = submit(last_step, processor.add_track, track)
+
+    last_step = submit(last_step, processor.commit)
+
+    # these can all run in parallel, so they don't need to update last_step
+    for step in (processor.write_cue,
+                 processor.write_kunaki_cue,
+                 processor.write_tsv):
+        submit(last_step, step)
+
+    return futures

--- a/bandcrash/cdda.py
+++ b/bandcrash/cdda.py
@@ -222,16 +222,17 @@ class CDWriter:
         LOGGER.info("Writing TSV file to %s", fname)
 
         with open(os.path.join(self.output_dir, fname), 'w', encoding='utf-8') as tsv:
-            print('Index\tTitle\tDuration\tPerformer\tComposer', file=tsv)
+            print('Index\tTitle\tDuration\tStart Time\tPerformer\tComposer', file=tsv)
 
             def get_prop(track, key):
                 return ' '.join(track.get(key, self.album.get(key, '')).split())
-            for idx, (track, _, duration) in enumerate(self.tracks, start=1):
+            for idx, (track, offset, duration) in enumerate(self.tracks, start=1):
                 minutes, seconds = divmod(duration, 60)
                 print('\t'.join([
                     str(idx),
                     get_prop(track, 'title'),
                     f'{int(minutes)}:{int(seconds+0.5):02}',
+                    format_time(offset),
                     get_prop(track, 'artist'),
                     get_prop(track, 'composer')
                 ]), file=tsv)

--- a/bandcrash/cdda.py
+++ b/bandcrash/cdda.py
@@ -231,7 +231,7 @@ class CDWriter:
                 print('\t'.join([
                     str(idx),
                     get_prop(track, 'title'),
-                    f'{int(minutes)}:{seconds+0.5:02.2}',
+                    f'{int(minutes)}:{int(seconds+0.5):02}',
                     get_prop(track, 'artist'),
                     get_prop(track, 'composer')
                 ]), file=tsv)

--- a/bandcrash/cli.py
+++ b/bandcrash/cli.py
@@ -81,6 +81,9 @@ def parse_args():
                         help="Prefix for the Butler channel name",
                         default=None)
 
+    parser.add_argument('--butler-args', type=str, default='',
+                        help="Extra arguments to provide to butler")
+
     return parser.parse_args()
 
 

--- a/bandcrash/gui/__init__.py
+++ b/bandcrash/gui/__init__.py
@@ -880,7 +880,7 @@ class BandcrashApplication(QApplication):
         QtCore.QTimer.singleShot(100, self.open_on_startup)
 
     @staticmethod
-    def instance() -> BandcrashApplication:
+    def instance():
         """ Get the current app instance """
         return typing.cast(BandcrashApplication, QApplication.instance())
 

--- a/bandcrash/gui/__init__.py
+++ b/bandcrash/gui/__init__.py
@@ -761,6 +761,8 @@ class AlbumEditor(QMainWindow):
         config.output_dir = os.path.join(
             self.output_dir, util.slugify_filename(' - '.join(filename_parts)))
 
+        config.butler_args = BandcrashApplication.instance().config.butler_args.split()
+
         LOGGER.info("Album data: %s", self.data)
         LOGGER.info("Config options: %s", config)
 
@@ -865,18 +867,20 @@ class AlbumEditor(QMainWindow):
 class BandcrashApplication(QApplication):
     """ Application event handler """
 
-    def __init__(self, open_files):
+    def __init__(self, config):
         super().__init__()
+
+        self.config = config
 
         self.windows: set[AlbumEditor] = set()
 
-        for path in open_files:
+        for path in config.open_files:
             self.open_file(os.path.abspath(path))
 
         QtCore.QTimer.singleShot(100, self.open_on_startup)
 
     @staticmethod
-    def instance():
+    def instance() -> BandcrashApplication:
         """ Get the current app instance """
         return typing.cast(BandcrashApplication, QApplication.instance())
 
@@ -939,6 +943,8 @@ def main():
     parser.add_argument('--version', action='version',
                         version=f"%(prog)s {__version__}")
     parser.add_argument('open_files', type=str, nargs='*')
+    parser.add_argument('--butler-args', type=str, default='',
+                        help='Options to pass along to butler push')
     options = parser.parse_args()
 
     logging.basicConfig(level=LOG_LEVELS[min(
@@ -948,7 +954,7 @@ def main():
     LOGGER.debug(
         "Opening bandcrash GUI with provided files: %s", options.open_files)
 
-    app = BandcrashApplication(options.open_files)
+    app = BandcrashApplication(options)
 
     app.exec()
 


### PR DESCRIPTION
Improves the way in which the stages are constructed, by rolling 'build' and 'clean' into the end of the 'encode', dropping the 'encode-' prefix on the encode stage name, and splitting the cdda phases out into separate tasks with appropriate parallelism so that the GUI can show progress.

This fixes #132 